### PR TITLE
Create EKS

### DIFF
--- a/ephemeral-resources/data-sources.tf
+++ b/ephemeral-resources/data-sources.tf
@@ -1,0 +1,14 @@
+data "aws_vpc" "master-vpc" {
+  filter {
+    name = "tag:Name"
+    values = ["${var.project}-vpc"]
+  }
+}
+
+data "aws_subnets" "master-subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.master-vpc.id]
+  }
+  depends_on = [ data.aws_vpc.master-vpc ]
+}

--- a/ephemeral-resources/data-sources.tf
+++ b/ephemeral-resources/data-sources.tf
@@ -1,6 +1,6 @@
 data "aws_vpc" "master-vpc" {
   filter {
-    name = "tag:Name"
+    name   = "tag:Name"
     values = ["${var.project}-vpc"]
   }
 }
@@ -10,5 +10,5 @@ data "aws_subnets" "master-subnets" {
     name   = "vpc-id"
     values = [data.aws_vpc.master-vpc.id]
   }
-  depends_on = [ data.aws_vpc.master-vpc ]
+  depends_on = [data.aws_vpc.master-vpc]
 }

--- a/ephemeral-resources/eks-control-plane.tf
+++ b/ephemeral-resources/eks-control-plane.tf
@@ -3,13 +3,13 @@
 # Policy to Allow EKS Service assume IAM Roles (any role). EKS will be granted a temp token, a token with the permissions to assume IAM Roles:
 data "aws_iam_policy_document" "eks-assume-role" {
   statement {
-    effect = "Allow"   # Allow the service to assume the Role
+    effect = "Allow" # Allow the service to assume the Role
 
-    principals {  # Identifying the service that can assume the Role
-      type        = "Service"   
+    principals { # Identifying the service that can assume the Role
+      type        = "Service"
       identifiers = ["eks.amazonaws.com"]
     }
-    actions = ["sts:AssumeRole"]   # Here is the allowed Action
+    actions = ["sts:AssumeRole"] # Here is the allowed Action
   }
 }
 
@@ -33,7 +33,7 @@ resource "aws_eks_cluster" "eks-cluster" {
   name = "${var.project}-eks-${terraform.workspace}"
   # EKS will use this role when interacting with other AWS Services
   role_arn = aws_iam_role.master-eks-role.arn
-  version = "1.27"
+  version  = "1.27"
 
   kubernetes_network_config {
     # CIDR block to assign to Kubernetes pod and service IP address

--- a/ephemeral-resources/eks-control-plane.tf
+++ b/ephemeral-resources/eks-control-plane.tf
@@ -1,0 +1,61 @@
+########### IAM ROLES RELATED TO EKS - CONTROL PLANE #############
+
+# Policy to Allow EKS Service assume IAM Roles (any role). EKS will be granted a temp token, a token with the permissions to assume IAM Roles:
+data "aws_iam_policy_document" "eks-assume-role" {
+  statement {
+    effect = "Allow"   # Allow the service to assume the Role
+
+    principals {  # Identifying the service that can assume the Role
+      type        = "Service"   
+      identifiers = ["eks.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]   # Here is the allowed Action
+  }
+}
+
+# The Policy Document above will be attached to the Role, so the EKS service will be able to assume THIS role
+resource "aws_iam_role" "master-eks-role" {
+  name               = "master-eks-role-${terraform.workspace}"
+  assume_role_policy = data.aws_iam_policy_document.eks-assume-role.json
+}
+
+# Built-in IAM Policy that allows the EKS to call other AWS Services
+# https://docs.aws.amazon.com/eks/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonEKSClusterPolicy
+resource "aws_iam_role_policy_attachment" "AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.master-eks-role.name
+}
+
+################################ EOF ###################################
+
+# Create EKS Cluster
+resource "aws_eks_cluster" "eks-cluster" {
+  name = "${var.project}-eks-${terraform.workspace}"
+  # EKS will use this role when interacting with other AWS Services
+  role_arn = aws_iam_role.master-eks-role.arn
+  version = "1.27"
+
+  kubernetes_network_config {
+    # CIDR block to assign to Kubernetes pod and service IP address
+    # Recommendation is to do not overlap any other resources in other network that is peered with the cluster VPC
+    # Can't overlap with any CIDR block assigned to the cluster VPC
+    # Need to be between /24 and /12
+    service_ipv4_cidr = "172.30.0.0/16"
+    ip_family         = "ipv4"
+  }
+
+  vpc_config {
+    subnet_ids              = data.aws_subnets.master-subnets.ids # You can't change which subnets you want to use after cluster creation.
+    endpoint_public_access  = true
+    endpoint_private_access = true          # Enable EKS public API server endpoint https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+    public_access_cidrs     = ["0.0.0.0/0"] # EKS API server endpoint source IP, could be used to allow only VPN
+    # security_group_ids = [] TODO: make the cluster private
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSClusterPolicy,
+    #aws_iam_role_policy_attachment.example-AmazonEKSVPCResourceController
+  ]
+}

--- a/ephemeral-resources/eks-worker-nodes.tf
+++ b/ephemeral-resources/eks-worker-nodes.tf
@@ -1,0 +1,78 @@
+################## IAM ROLE FOR EKS WORKER NODES ###################
+
+# IAM Role with attached policy allowing EC2 instances assume this role. EC2 will be granted a temp token, a token with the permissions to assume this Role
+# Check eks-control-plane.tf file, I used a different approach there that do the same
+resource "aws_iam_role" "master-eks-workers-role" {
+  name = "master-eks-workers-role-${terraform.workspace}"
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+### Built-in IAM Policies that allows the EC2 to call other AWS Services ###
+
+# This policy allows Amazon EKS worker nodes to connect to Amazon EKS Clusters
+# https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKSWorkerNodePolicy.html
+resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.master-eks-workers-role.name
+}
+
+# This policy provides the Amazon VPC CNI Plugin (amazon-vpc-cni-k8s) the permissions it requires to modify the IP address configuration on your EKS worker nodes.
+# https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEKS_CNI_Policy.html
+resource "aws_iam_role_policy_attachment" "AmazonEKS_CNI_Policy-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.master-eks-workers-role.name
+}
+
+# Provides read-only access to Amazon EC2 Container Registry repositories
+# https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html
+resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.master-eks-workers-role.name
+}
+
+### EOF ###
+
+#################################### EOF ##########################################
+
+# Create two EKS Node Groups
+resource "aws_eks_node_group" "master-eks-workers" {
+  count = 2
+  cluster_name    = aws_eks_cluster.eks-cluster.name
+  node_group_name = "${var.project}-eks-node-group-${count.index}-${terraform.workspace}"
+  node_role_arn   = aws_iam_role.master-eks-workers-role.arn
+  subnet_ids      = [data.aws_subnets.master-subnets.ids["${count.index}"]]
+  capacity_type   = "ON_DEMAND"
+  instance_types  = ["t3.micro"]
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 2
+    min_size     = 1
+  }
+  update_config {
+    max_unavailable = 1
+  }
+
+# Allow external changes without Terraform plan difference
+    lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Node Group handling.
+  # Otherwise, EKS will not be able to properly delete EC2 Instances and Elastic Network Interfaces.
+  depends_on = [
+    aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy-attachment,
+    aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy-attachment,
+    aws_iam_role_policy_attachment.AmazonEC2ContainerRegistryReadOnly-attachment,
+  ]
+}

--- a/ephemeral-resources/eks-worker-nodes.tf
+++ b/ephemeral-resources/eks-worker-nodes.tf
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly-at
 
 # Create two EKS Node Groups
 resource "aws_eks_node_group" "master-eks-workers" {
-  count = 2
+  count           = 2
   cluster_name    = aws_eks_cluster.eks-cluster.name
   node_group_name = "${var.project}-eks-node-group-${count.index}-${terraform.workspace}"
   node_role_arn   = aws_iam_role.master-eks-workers-role.arn
@@ -63,8 +63,8 @@ resource "aws_eks_node_group" "master-eks-workers" {
     max_unavailable = 1
   }
 
-# Allow external changes without Terraform plan difference
-    lifecycle {
+  # Allow external changes without Terraform plan difference
+  lifecycle {
     ignore_changes = [scaling_config[0].desired_size]
   }
 

--- a/ephemeral-resources/variables.tf
+++ b/ephemeral-resources/variables.tf
@@ -1,0 +1,3 @@
+variable "project" {
+  default = "platform-master"
+}

--- a/ephemeral-resources/versions.tf
+++ b/ephemeral-resources/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-        source = "hashicorp/aws"
-        version = "~>5.19.0"
+      source  = "hashicorp/aws"
+      version = "~>5.19.0"
     }
   }
   backend "s3" {
@@ -18,8 +18,8 @@ provider "aws" {
   region = "eu-north-1"
   default_tags {
     tags = {
-      project = var.project
-      owner= "Benhur A. Silva"
+      project        = var.project
+      owner          = "Benhur A. Silva"
       owner-linkedin = "linkedin.com/in/benhuraraujo/"
     }
   }

--- a/ephemeral-resources/versions.tf
+++ b/ephemeral-resources/versions.tf
@@ -9,7 +9,7 @@ terraform {
   }
   backend "s3" {
     bucket = "platform-master"
-    key    = "tf-states/aws-environments/terraform.tfstate"
+    key    = "tf-states/aws-environments/ephemeral-resources/terraform.tfstate"
     region = "eu-north-1"
   }
 }

--- a/networking.tf
+++ b/networking.tf
@@ -1,12 +1,12 @@
 # Default VPC for "Platform-Master" Project
 resource "aws_vpc" "master-vpc" {
-  cidr_block = "172.20.0.0/16"
+  cidr_block       = "172.20.0.0/16"
   instance_tenancy = "default"
 
   ### https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support
   ### https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#AmazonDNS
-  enable_dns_hostnames = true      # Assign Public DNS hostname to instances with public IPs
-  enable_dns_support = true        # DNS resolution through the Amazon provided DNS server (DNS Resolver service which is built into each availability zone within an AWS Region)
+  enable_dns_hostnames = true # Assign Public DNS hostname to instances with public IPs
+  enable_dns_support   = true # DNS resolution through the Amazon provided DNS server (DNS Resolver service which is built into each availability zone within an AWS Region)
   ###
   tags = {
     Name = "${var.project}-vpc"
@@ -17,7 +17,7 @@ resource "aws_vpc" "master-vpc" {
 # https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html
 resource "aws_internet_gateway" "master-igw" {
   vpc_id = aws_vpc.master-vpc.id
-  
+
   tags = {
     Name = "${var.project}-igw"
   }
@@ -39,10 +39,10 @@ resource "aws_route_table" "master-rt" {
 
 # Create two subnets at differents AZs
 resource "aws_subnet" "master-subnets-public" {
-  for_each = local.availability_zones
-  vpc_id = aws_vpc.master-vpc.id
-  cidr_block = "172.20.${index(values(local.availability_zones), "${each.value}")}.0/24"
-  availability_zone = each.value
+  for_each                = local.availability_zones
+  vpc_id                  = aws_vpc.master-vpc.id
+  cidr_block              = "172.20.${index(values(local.availability_zones), "${each.value}")}.0/24"
+  availability_zone       = each.value
   map_public_ip_on_launch = true
 
   tags = {
@@ -52,7 +52,7 @@ resource "aws_subnet" "master-subnets-public" {
 
 # Attach Internet Route Table to the Subnets, so they become Public Subnets
 resource "aws_route_table_association" "master-rt-association" {
-  for_each = local.availability_zones
+  for_each       = local.availability_zones
   subnet_id      = aws_subnet.master-subnets-public[each.key].id
   route_table_id = aws_route_table.master-rt.id
 }

--- a/networking.tf
+++ b/networking.tf
@@ -43,6 +43,7 @@ resource "aws_subnet" "master-subnets-public" {
   vpc_id = aws_vpc.master-vpc.id
   cidr_block = "172.20.${index(values(local.availability_zones), "${each.value}")}.0/24"
   availability_zone = each.value
+  map_public_ip_on_launch = true
 
   tags = {
     Name = "${var.project}-subnet-public"

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-        source = "hashicorp/aws"
-        version = "~>5.19.0"
+      source  = "hashicorp/aws"
+      version = "~>5.19.0"
     }
   }
   backend "s3" {
@@ -18,8 +18,8 @@ provider "aws" {
   region = "eu-north-1"
   default_tags {
     tags = {
-      project = var.project
-      owner= "Benhur A. Silva"
+      project        = var.project
+      owner          = "Benhur A. Silva"
       owner-linkedin = "linkedin.com/in/benhuraraujo/"
     }
   }


### PR DESCRIPTION
> terraform apply --auto-approve
data.aws_vpc.master-vpc: Reading...
data.aws_iam_policy_document.eks-assume-role: Reading...
data.aws_iam_policy_document.eks-assume-role: Read complete after 0s [id=3552664922]
data.aws_vpc.master-vpc: Read complete after 2s [id=vpc-02876b4f4c45922d9]
data.aws_subnets.master-subnets: Reading...
data.aws_subnets.master-subnets: Read complete after 1s [id=eu-north-1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eks_cluster.eks-cluster will be created
  + resource "aws_eks_cluster" "eks-cluster" {
      + arn                   = (known after apply)
      + certificate_authority = (known after apply)
      + cluster_id            = (known after apply)
      + created_at            = (known after apply)
      + endpoint              = (known after apply)
      + id                    = (known after apply)
      + identity              = (known after apply)
      + name                  = "platform-master-eks-dev"
      + platform_version      = (known after apply)
      + role_arn              = (known after apply)
      + status                = (known after apply)
      + tags_all              = {
          + "owner"          = "Benhur A. Silva"
          + "owner-linkedin" = "linkedin.com/in/benhuraraujo/"
          + "project"        = "platform-master"
        }
      + version               = "1.27"

      + kubernetes_network_config {
          + ip_family         = "ipv4"
          + service_ipv4_cidr = "172.30.0.0/16"
          + service_ipv6_cidr = (known after apply)
        }

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = true
          + endpoint_public_access    = true
          + public_access_cidrs       = [
              + "0.0.0.0/0",
            ]
          + subnet_ids                = [
              + "subnet-04b64961b6ea82be6",
              + "subnet-08c4ca3fbd12b3dc6",
            ]
          + vpc_id                    = (known after apply)
        }
    }

  # aws_eks_node_group.master-eks-workers[0] will be created
  + resource "aws_eks_node_group" "master-eks-workers" {
      + ami_type               = (known after apply)
      + arn                    = (known after apply)
      + capacity_type          = "ON_DEMAND"
      + cluster_name           = "platform-master-eks-dev"
      + disk_size              = (known after apply)
      + id                     = (known after apply)
      + instance_types         = [
          + "t3.micro",
        ]
      + node_group_name        = "platform-master-eks-node-group-0-dev"
      + node_group_name_prefix = (known after apply)
      + node_role_arn          = (known after apply)
      + release_version        = (known after apply)
      + resources              = (known after apply)
      + status                 = (known after apply)
      + subnet_ids             = [
          + "subnet-08c4ca3fbd12b3dc6",
        ]
      + tags_all               = {
          + "owner"          = "Benhur A. Silva"
          + "owner-linkedin" = "linkedin.com/in/benhuraraujo/"
          + "project"        = "platform-master"
        }
      + version                = (known after apply)

      + scaling_config {
          + desired_size = 1
          + max_size     = 2
          + min_size     = 1
        }

      + update_config {
          + max_unavailable = 1
        }
    }

  # aws_eks_node_group.master-eks-workers[1] will be created
  + resource "aws_eks_node_group" "master-eks-workers" {
      + ami_type               = (known after apply)
      + arn                    = (known after apply)
      + capacity_type          = "ON_DEMAND"
      + cluster_name           = "platform-master-eks-dev"
      + disk_size              = (known after apply)
      + id                     = (known after apply)
      + instance_types         = [
          + "t3.micro",
        ]
      + node_group_name        = "platform-master-eks-node-group-1-dev"
      + node_group_name_prefix = (known after apply)
      + node_role_arn          = (known after apply)
      + release_version        = (known after apply)
      + resources              = (known after apply)
      + status                 = (known after apply)
      + subnet_ids             = [
          + "subnet-04b64961b6ea82be6",
        ]
      + tags_all               = {
          + "owner"          = "Benhur A. Silva"
          + "owner-linkedin" = "linkedin.com/in/benhuraraujo/"
          + "project"        = "platform-master"
        }
      + version                = (known after apply)

      + scaling_config {
          + desired_size = 1
          + max_size     = 2
          + min_size     = 1
        }

      + update_config {
          + max_unavailable = 1
        }
    }

  # aws_iam_role.master-eks-role will be created
  + resource "aws_iam_role" "master-eks-role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "master-eks-role-dev"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "owner"          = "Benhur A. Silva"
          + "owner-linkedin" = "linkedin.com/in/benhuraraujo/"
          + "project"        = "platform-master"
        }
      + unique_id             = (known after apply)
    }

  # aws_iam_role.master-eks-workers-role will be created
  + resource "aws_iam_role" "master-eks-workers-role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "master-eks-workers-role-dev"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = {
          + "owner"          = "Benhur A. Silva"
          + "owner-linkedin" = "linkedin.com/in/benhuraraujo/"
          + "project"        = "platform-master"
        }
      + unique_id             = (known after apply)
    }

  # aws_iam_role_policy_attachment.AmazonEC2ContainerRegistryReadOnly-attachment will be created
  + resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly-attachment" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
      + role       = "master-eks-workers-role-dev"
    }

  # aws_iam_role_policy_attachment.AmazonEKSClusterPolicy will be created
  + resource "aws_iam_role_policy_attachment" "AmazonEKSClusterPolicy" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = "master-eks-role-dev"
    }

  # aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy-attachment will be created
  + resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy-attachment" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
      + role       = "master-eks-workers-role-dev"
    }

  # aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy-attachment will be created
  + resource "aws_iam_role_policy_attachment" "AmazonEKS_CNI_Policy-attachment" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
      + role       = "master-eks-workers-role-dev"
    }

Plan: 9 to add, 0 to change, 0 to destroy.